### PR TITLE
fix: restore publish workflow YAML parsing

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       image_name:
-        description: Custom image tag to publish (for example: fix-22-v0.0.1)
+        description: "Custom image tag to publish (for example: fix-22-v0.0.1)"
         required: false
         type: string
   push:


### PR DESCRIPTION
## Summary
- quote the workflow_dispatch input description so the workflow file is valid YAML
- restore the publish workflow after the invalid description string caused GitHub to reject the file

## Verification
- python YAML parse check for .github/workflows/publish-image.yml
- docker compose --profile staging up -d --build
- curl -sf http://localhost:8000/api/health