### PR TITLE
fix: retry coordinator startup connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ docker compose up -d
 ### Staging Mode
 Runs with simulated DUTs (Alpine Linux containers) and real Labgrid Exporters. Commands are executed via `labgrid-client` CLI, which properly routes through: Backend → Coordinator → Exporter → DUT.
 
+If the backend starts before the coordinator becomes reachable, it remains available in degraded mode and retries the coordinator connection automatically in the background.
+
 ```bash
 # Start with real command execution
 docker compose --profile staging up -d --build

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ Handles startup/shutdown lifecycle, CORS configuration, and route registration.
 
 import asyncio
 import logging
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from typing import AsyncGenerator
 
 from app.api import api_router
@@ -18,7 +18,7 @@ from app.api.routes.targets import set_preset_service as set_targets_preset_serv
 from app.api.routes.targets import (
     set_scheduler_service as set_targets_scheduler_service,
 )
-from app.api.websocket import broadcast_target_update
+from app.api.websocket import broadcast_target_update, broadcast_targets_list
 from app.api.websocket import set_command_service as set_ws_command_service
 from app.api.websocket import set_labgrid_client as set_ws_labgrid_client
 from app.api.websocket import set_scheduler_service as set_ws_scheduler_service
@@ -37,6 +37,9 @@ logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger(__name__)
+
+COORDINATOR_RECONNECT_INITIAL_DELAY_SECONDS = 5
+COORDINATOR_RECONNECT_MAX_DELAY_SECONDS = 60
 
 # Global service instances
 labgrid_client: LabgridClient | None = None
@@ -61,6 +64,76 @@ async def wait_for_targets_ready(
         await asyncio.sleep(poll_interval_seconds)
 
 
+async def sync_coordinator_runtime(
+    client: LabgridClient,
+    timeout_seconds: int,
+    poll_interval_seconds: int,
+    target_update_callback,
+) -> None:
+    """Wait for coordinator data and restore target update subscriptions."""
+    logger.info("Waiting for coordinator synchronization...")
+    targets_ready = await wait_for_targets_ready(
+        client,
+        timeout_seconds,
+        poll_interval_seconds,
+    )
+    if targets_ready:
+        logger.info("Coordinator synchronization complete")
+    else:
+        logger.warning(
+            "Coordinator synchronization timed out, continuing with current state"
+        )
+
+    updates_enabled = await client.subscribe_updates(target_update_callback)
+    if not updates_enabled:
+        logger.warning("Target update subscription disabled (no coordinator connection)")
+        return
+
+    logger.info("Coordinator target updates enabled")
+    await broadcast_targets_list()
+
+
+async def reconnect_coordinator_in_background(
+    client: LabgridClient,
+    timeout_seconds: int,
+    poll_interval_seconds: int,
+    target_update_callback,
+) -> None:
+    """Retry coordinator connection after startup failures until it succeeds."""
+    retry_delay = COORDINATOR_RECONNECT_INITIAL_DELAY_SECONDS
+
+    while True:
+        logger.info(
+            "Coordinator unavailable during startup, retrying in %s seconds",
+            retry_delay,
+        )
+
+        await asyncio.sleep(retry_delay)
+
+        try:
+            await client.connect()
+            logger.info("Coordinator reconnect succeeded")
+            await sync_coordinator_runtime(
+                client,
+                timeout_seconds,
+                poll_interval_seconds,
+                target_update_callback,
+            )
+            return
+        except asyncio.CancelledError:
+            raise
+        except LabgridConnectionError as exc:
+            logger.warning("Coordinator reconnect attempt failed: %s", exc)
+        except Exception:
+            logger.exception("Unexpected error during coordinator reconnect attempt")
+
+        await client.disconnect()
+        retry_delay = min(
+            retry_delay * 2,
+            COORDINATOR_RECONNECT_MAX_DELAY_SECONDS,
+        )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Manage application lifecycle - startup and shutdown events.
@@ -76,6 +149,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     settings = get_settings()
     logger.info("Starting Labgrid Dashboard Backend...")
+    reconnect_task: asyncio.Task[None] | None = None
 
     # Initialize command service
     command_service = CommandService(commands_file=settings.commands_file)
@@ -111,19 +185,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             "Failed to connect to coordinator during startup. "
             "Starting API in degraded mode."
         )
-    else:
-        logger.info("Waiting for coordinator synchronization...")
-        targets_ready = await wait_for_targets_ready(
-            labgrid_client,
-            settings.coordinator_timeout,
-            settings.labgrid_poll_interval_seconds,
-        )
-        if targets_ready:
-            logger.info("Coordinator synchronization complete")
-        else:
-            logger.warning(
-                "Coordinator synchronization timed out, starting scheduler anyway"
-            )
+        await labgrid_client.disconnect()
 
     # Initialize scheduler service with preset support
     scheduler_service = SchedulerService()
@@ -150,14 +212,28 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     set_ws_command_service(command_service)
     set_ws_scheduler_service(scheduler_service)
 
-    await scheduler_service.start()
-
     async def handle_target_update(target_name: str, target_data: dict) -> None:
         await broadcast_target_update(target_data)
 
-    updates_enabled = await labgrid_client.subscribe_updates(handle_target_update)
-    if not updates_enabled:
-        logger.warning("Target update subscription disabled (no coordinator connection)")
+    if labgrid_client.connected:
+        await sync_coordinator_runtime(
+            labgrid_client,
+            settings.coordinator_timeout,
+            settings.labgrid_poll_interval_seconds,
+            handle_target_update,
+        )
+
+    await scheduler_service.start()
+
+    if not labgrid_client.connected:
+        reconnect_task = asyncio.create_task(
+            reconnect_coordinator_in_background(
+                labgrid_client,
+                settings.coordinator_timeout,
+                settings.labgrid_poll_interval_seconds,
+                handle_target_update,
+            )
+        )
 
     logger.info("Labgrid Dashboard Backend started successfully")
 
@@ -168,6 +244,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     if scheduler_service:
         await scheduler_service.stop()
+
+    if reconnect_task and not reconnect_task.done():
+        reconnect_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await reconnect_task
 
     if labgrid_client:
         await labgrid_client.disconnect()

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,0 +1,69 @@
+"""
+Tests for startup and reconnect behavior in the main application module.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.main import (
+    COORDINATOR_RECONNECT_INITIAL_DELAY_SECONDS,
+    reconnect_coordinator_in_background,
+    sync_coordinator_runtime,
+)
+from app.services.labgrid_client import LabgridConnectionError
+
+
+@pytest.mark.asyncio
+async def test_sync_coordinator_runtime_restores_updates_and_broadcasts():
+    """Test that synchronization restores subscriptions and broadcasts targets."""
+    client = MagicMock()
+    client.subscribe_updates = AsyncMock(return_value=True)
+    callback = AsyncMock()
+
+    with patch("app.main.wait_for_targets_ready", new=AsyncMock(return_value=True)):
+        with patch("app.main.broadcast_targets_list", new=AsyncMock()) as broadcast:
+            await sync_coordinator_runtime(
+                client,
+                timeout_seconds=30,
+                poll_interval_seconds=5,
+                target_update_callback=callback,
+            )
+
+    client.subscribe_updates.assert_awaited_once_with(callback)
+    broadcast.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_coordinator_in_background_retries_until_success():
+    """Test that the reconnect loop retries failed startup connections."""
+    client = MagicMock()
+    client.connect = AsyncMock(
+        side_effect=[
+            LabgridConnectionError("startup failed"),
+            True,
+        ]
+    )
+    client.disconnect = AsyncMock()
+    callback = AsyncMock()
+    sleep_calls: list[int] = []
+
+    async def fake_sleep(seconds: int) -> None:
+        sleep_calls.append(seconds)
+
+    with patch("app.main.asyncio.sleep", new=fake_sleep):
+        with patch("app.main.sync_coordinator_runtime", new=AsyncMock()) as sync_runtime:
+            await reconnect_coordinator_in_background(
+                client,
+                timeout_seconds=30,
+                poll_interval_seconds=5,
+                target_update_callback=callback,
+            )
+
+    assert sleep_calls == [
+        COORDINATOR_RECONNECT_INITIAL_DELAY_SECONDS,
+        COORDINATOR_RECONNECT_INITIAL_DELAY_SECONDS * 2,
+    ]
+    assert client.connect.await_count == 2
+    client.disconnect.assert_awaited_once()
+    sync_runtime.assert_awaited_once_with(client, 30, 5, callback)


### PR DESCRIPTION
## Summary
- retry coordinator connections in the background when startup begins in degraded mode
- restore target subscriptions and broadcast a fresh targets list after recovery
- cover the reconnect lifecycle with backend tests and document the behavior in the staging README

## Notes
- Fixes #23

## Verification
- DEBUG=false python -m pytest tests/test_main.py tests/test_health.py (run from backend/)
- docker compose --profile staging up -d --build
- curl -sf http://localhost:8000/api/health
